### PR TITLE
returns Errno::ECONNRESET instead of a simple string

### DIFF
--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -22,7 +22,7 @@ module EventMachine::Hiredis
 
       @connection.on(:closed) do
         if @connected
-          @defs.each { |d| d.fail("Redis disconnected") }
+          @defs.each { |d| d.fail(Errno::ECONNRESET) }
           @defs = []
           @deferred_status = nil
           @connected = false


### PR DESCRIPTION
When the redis disconnect, the message "Redis disconnected" was given to the Defferable.fail method.
A errno value is easier to check than a simple string.
