### PR TITLE
Fix INFO command parsing

### DIFF
--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -150,6 +150,24 @@ module EventMachine::Hiredis
       method_missing(:info, &hash_processor)
     end
 
+    def info_commandstats(&blk)
+      hash_processor = lambda do |response|
+        commands = {}
+        response.each_line do |line|
+          command, data = line.split(':')
+          if data
+            c = commands[command.sub('cmdstat_', '').to_sym] = {}
+            data.split(',').each do |d|
+              k, v = d.split('=')
+              c[k.to_sym] = v =~ /\./ ? v.to_f : v.to_i
+            end
+          end
+        end
+        blk.call(commands)
+      end
+      method_missing(:info, 'commandstats', &hash_processor)
+    end
+
     def close_connection
       @closing_connection = true
       @connection.close_connection_after_writing

--- a/spec/redis_commands_spec.rb
+++ b/spec/redis_commands_spec.rb
@@ -619,6 +619,17 @@ describe EventMachine::Hiredis, "commands" do
     end
   end
 
+  it "provides commandstats (INFO COMMANDSTATS)" do
+    connect do |redis|
+      redis.info_commandstats do |r|
+        r[:get][:calls].should be_a_kind_of(Integer)
+        r[:get][:usec].should be_a_kind_of(Integer)
+        r[:get][:usec_per_call].should be_a_kind_of(Float)
+        done
+      end
+    end
+  end
+
   it "flushes the database (FLUSHDB)" do
     connect do |redis|
       redis.set('key1', 'keyone')


### PR DESCRIPTION
This patch fixes `INFO` parsing for Redis 2.6.
