### PR TITLE
Latest current em-hiredis

### DIFF
--- a/em-hiredis.gemspec
+++ b/em-hiredis.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Eventmachine redis client using hiredis native parser}
 
   s.add_dependency 'eventmachine', '~> 1.0'
-  s.add_dependency 'hiredis', '~> 0.6.0'
+  s.add_dependency 'hiredis', '~> 0.6.1'
 
   s.add_development_dependency 'em-spec', '~> 0.2.5'
   s.add_development_dependency 'rspec', '~> 2.6.0'


### PR DESCRIPTION
### Symptoms

```
Bundler could not find compatible versions for gem "hiredis":
  In Gemfile:
    hiredis (~> x.y.z)

    em-hiredis (~> 0.3.0) was resolved to 0.3.0, which depends on
      hiredis (~> 0.5.0)
```