### PR TITLE
Specify Logger sans namespace

### DIFF
--- a/lib/em-hiredis.rb
+++ b/lib/em-hiredis.rb
@@ -47,8 +47,8 @@ module EventMachine
     def self.logger
       @@logger ||= begin
         require 'logger'
-        log = Logger.new(STDOUT)
-        log.level = Logger::WARN
+        log = ::Logger.new(STDOUT)
+        log.level = ::Logger::WARN
         log
       end
     end


### PR DESCRIPTION
Loading in the https://github.com/stve/em-logger gem causes some issues where em-hiredis references the EM namespaced logger and not the system logger.

This change just forces the system logger to get used as intended