### PR TITLE
Remove Fixnum deprecation warning (from ruby 2.4)

### DIFF
--- a/em-hiredis.gemspec
+++ b/em-hiredis.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'em-spec', '~> 0.2.5'
   s.add_development_dependency 'rspec', '~> 2.6.0'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11.0'
 
   s.rubyforge_project = "em-hiredis"
 

--- a/lib/em-hiredis/lock.rb
+++ b/lib/em-hiredis/lock.rb
@@ -13,7 +13,7 @@ module EM::Hiredis
     def onexpire(&blk); @onexpire = blk; end
 
     def initialize(redis, key, timeout)
-      unless timeout.kind_of?(Fixnum) && timeout >= 1
+      unless timeout.kind_of?(Integer) && timeout >= 1
         raise "Timeout must be an integer and >= 1s"
       end
       @redis, @key, @timeout = redis, key, timeout


### PR DESCRIPTION
Hello

This MR does 2 things:

- Remove the deprecation warning on Fixnum with ruby 2.4 (tested with ruby 2.4.1 & 2.5.1)
- Limit rake version to keep rspec compatibility (when I bundled without I got an uncompatible version of rake wich led me here https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11)

Maybe this should be splitted in 2 different PR but i believed it's minor enough not to bother ^^"