### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/em-hiredis.gemspec
+++ b/em-hiredis.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'rake', '< 11.0'
 
-  s.rubyforge_project = "em-hiredis"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.