### PR TITLE
TLS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ This configuration is per client, you may choose different value for clients wit
 Because the Redis Pubsub protocol limits the set of valid commands on a connection once it is in "Pubsub" mode, `PING` is not supported in this case (though it may be in future, see https://github.com/antirez/redis/issues/420). In order to create some valid request-response traffic on the connection, a Pubsub connection will issue `SUBSCRIBE "__em-hiredis-ping"`, followed by a corresponding `UNSUBSCRIBE` immediately on success of the subscribe.
 While less than ideal, this is the case where an application layer inactivity check is most valuable, and so the trade off is reasonable until `PING` is supported correctly on Pubsub connections.
 
+## TLS
+
+Redis 6 added TLS support. EM::Hiredis will interpret a rediss://... URL (note the extra s) as requiring TLS.
+
 ## Developing
 
 You need bundler and a local redis server running on port 6379 to run the test suite.

--- a/em-hiredis.gemspec
+++ b/em-hiredis.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Eventmachine redis client}
   s.description = %q{Eventmachine redis client using hiredis native parser}
 
-  s.add_dependency 'eventmachine', '~> 1.0'
+  s.add_dependency 'eventmachine', '~> 1.2'
   s.add_dependency 'hiredis', '~> 0.6.0'
 
   s.add_development_dependency 'em-spec', '~> 0.2.5'

--- a/lib/em-hiredis.rb
+++ b/lib/em-hiredis.rb
@@ -16,7 +16,7 @@ module EventMachine
     end
     self.reconnect_timeout = 0.5
 
-    def self.setup(uri = nil)
+    def self.setup(uri = nil, tls = false)
       uri = uri || ENV["REDIS_URL"] || "redis://127.0.0.1:6379/0"
       client = Client.new
       client.configure(uri)
@@ -29,13 +29,14 @@ module EventMachine
     # environment variable, or localhost:6379
     #
     # TCP connections are supported via redis://:password@host:port/db (only
-    # host and port components are required)
+    # host and port components are required). If rediss://... is passed, TLS
+    # is assumed.
     #
     # Unix socket uris are supported, e.g. unix:///tmp/redis.sock, however
     # it's not possible to set the db or password - use initialize instead in
     # this case
-    def self.connect(uri = nil)
-      client = setup(uri)
+    def self.connect(uri = nil, tls = false)
+      client = setup(uri, tls)
       client.connect
       client
     end

--- a/lib/em-hiredis/base_client.rb
+++ b/lib/em-hiredis/base_client.rb
@@ -110,7 +110,7 @@ module EventMachine::Hiredis
         @reconnect_failed_count = 0
         @failed = false
 
-        auth(@password) if @password
+        auth(@password) if @password && @password != ''
         select(@db) unless @db == 0
 
         @command_queue.each do |df, command, args|

--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -2,8 +2,8 @@ require 'digest/sha1'
 
 module EventMachine::Hiredis
   class Client < BaseClient
-    def self.connect(host = 'localhost', port = 6379)
-      new(host, port).connect
+    def self.connect(host = 'localhost', port = 6379, tls = false)
+      new(host, port, tls).connect
     end
 
     def self.load_scripts_from(dir)

--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -87,7 +87,7 @@ module EventMachine::Hiredis
     #
     def pubsub
       @pubsub ||= begin
-        PubsubClient.new(@host, @port, @password, @db).connect
+        PubsubClient.new(@host, @port, @password, @db, @tls).connect
       end
     end
 

--- a/lib/em-hiredis/connection.rb
+++ b/lib/em-hiredis/connection.rb
@@ -4,19 +4,21 @@ module EventMachine::Hiredis
   class Connection < EM::Connection
     include EventMachine::Hiredis::EventEmitter
 
-    def initialize(host, port)
+    def initialize(host, port, tls = false)
       super
-      @host, @port = host, port
-      @name = "[em-hiredis #{@host}:#{@port}]"
+      @host, @port, @tls = host, port, tls
+      @name = "[em-hiredis #{@host}:#{@port} tls:#{@tls}]"
     end
 
-    def reconnect(host, port)
-      super
-      @host, @port = host, port
+    def reconnect(host, port, tls = false)
+      super(host, port)
+      @host, @port, @tls = host, port, tls
     end
 
     def connection_completed
       @reader = ::Hiredis::Reader.new
+      tls_options = @tls == true ? { ssl_version: :tlsv1_2 } : @tls 
+      start_tls(tls_options) if tls_options
       emit(:connected)
     end
 

--- a/lib/em-hiredis/pubsub_client.rb
+++ b/lib/em-hiredis/pubsub_client.rb
@@ -4,8 +4,9 @@ module EventMachine::Hiredis
 
     PING_CHANNEL = '__em-hiredis-ping'
 
-    def initialize(host='localhost', port='6379', password=nil, db=nil)
+    def initialize(host='localhost', port='6379', password=nil, db=nil, tls=false)
       @subs, @psubs = [], []
+      @tls = tls
       @pubsub_defs = Hash.new { |h,k| h[k] = [] }
       super
     end


### PR DESCRIPTION
Redis 6 added TLS support.

This PR makes EM::Hiredis interpret a rediss://... URL (note the extra s) as requiring TLS.

I'm not sure how best to update the tests (which are failing for me locally on master prior to this PR) but am happy to work on them with some guidance.