### PR TITLE
Make em-hiredis compatible with ruby 2.7

### DIFF
--- a/lib/em-hiredis/client.rb
+++ b/lib/em-hiredis/client.rb
@@ -36,7 +36,7 @@ module EventMachine::Hiredis
         &df.method(:succeed)
       ).errback { |e|
         if e.kind_of?(RedisError) && e.redis_error.message.start_with?("NOSCRIPT")
-          self.eval(lua, keys.size, *keys, *args)
+          method_missing(:eval, lua, keys.size, *keys, *args)
             .callback(&df.method(:succeed)).errback(&df.method(:fail))
         else
           df.fail(e)


### PR DESCRIPTION
When trying to update a project to ruby 2.7 I ended up getting a few broken specs because of em-hiredis

```
Failure/Error:
   self.eval(lua, keys.size, *keys, *args)
     .callback(&df.method(:succeed)).errback(&df.method(:fail))
 ArgumentError:
   wrong number of arguments (given 5, expected 1..4)
  # /.../.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/bundler/gems/em-hiredis-c9eac4b938a1/lib/em-hiredis/client.rb:39:in `eval'
```
It appears that Kernel#eval is overriding the gem's eval method for some reason, so directly using method_missing with eval as an argument makes it work with ruby 2.7

All specs are working fine with the new fix